### PR TITLE
Remove open race

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -43,9 +43,10 @@ class Circuitbox
     end
 
     def run!(run_options = {})
-      if open?
+      currently_open = open_flag?
+      if currently_open || should_open?
         logger.debug "[CIRCUIT] open: skipping #{service}"
-        open! unless open_flag?
+        open! unless currently_open
         skipped!
         raise Circuitbox::OpenCircuitError.new(service)
       else
@@ -85,11 +86,15 @@ class Circuitbox
     def open?
       if open_flag?
         true
-      elsif passed_volume_threshold? && passed_rate_threshold?
+      elsif should_open?
         true
       else
         false
       end
+    end
+
+    def should_open?
+      passed_volume_threshold? && passed_rate_threshold?
     end
 
     def error_rate(failures = failure_count, success = success_count)

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -234,7 +234,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_records_response_skipped
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open? => true)
+    circuit.stubs(:should_open? => true)
     circuit.stubs(:log_event)
     circuit.expects(:log_event).with(:skipped)
     emulate_circuit_run(circuit, :failure, Timeout::Error)
@@ -262,7 +262,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_puts_circuit_to_sleep_once_opened
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open? => true)
+    circuit.stubs(:should_open? => true)
 
     assert !circuit.send(:open_flag?)
     emulate_circuit_run(circuit, :failure, Timeout::Error)


### PR DESCRIPTION
It appears we found a race condition where the circuit was latched open.  It appears to be due to this logic:

```
      if open?
        logger.debug "[CIRCUIT] open: skipping #{service}"
        open! unless open_flag?
```

`open?` calls `open_flag?`

If the first call is true, but then the flag expires before the second call, we will call `open!` without trying another request, latching the circuit open for another sleep window.

This pr only checks the `open_flag?` once to avoid that race.